### PR TITLE
docs: fix wrong explanation in `Configurations.mdx`

### DIFF
--- a/docs/linting/Configurations.mdx
+++ b/docs/linting/Configurations.mdx
@@ -56,7 +56,7 @@ Additionally, we provide a [`stylistic`](#stylistic) config that enforces concis
 We recommend that most projects should extend from either:
 
 - [`stylistic`](#stylistic): Stylistic rules you can drop in without additional configuration.
-- [`stylistic-type-checked`](#stylistic-type-checked): Contains `strict` + additional stylistic rules that require type information.
+- [`stylistic-type-checked`](#stylistic-type-checked): Contains `stylistic` + additional stylistic rules that require type information.
 
 :::note
 These configurations are our recommended starting points, but **you don't need to use them as-is**.


### PR DESCRIPTION
## PR Checklist

- [ ] ~Addresses an existing open issue: fixes #000~
- [ ] ~That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)~
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Explanation of `stylistic-type-checked` in section `Recommended Configurations` refers to `strict` instead of `stylistic`.
